### PR TITLE
export metrics via new endpoint /metrics

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -38,13 +38,7 @@ func deleteTodoHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func healthCheckHandler(rw http.ResponseWriter, req *http.Request) {
-	okString := "ok"
-	result := map[string]string{"self": okString}
-
-	checkConnection(result, "redis-master", masterConnection, masterPassword, okString)
-	checkConnection(result, "redis-slave", slaveConnection, slavePassword, okString)
-
-	generateJSONResponse(rw, result)
+	generateJSONResponse(rw, getHealthStatus())
 }
 
 func whoAmIHandler(rw http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/negroni"
 )
 
@@ -13,6 +14,13 @@ var slavePassword string
 var masterConnection string
 var masterPassword string
 
+var APP_VERSION string = "latest" // Change this by setting compile flag -ldflags "-X main.APP_VERSION=${CI_GIT_TAG}"
+
+func init() {
+	// Metrics have to be registered to be exposed:
+	registerMetrics()
+}
+
 func main() {
 	flag.StringVar(&masterConnection, "master", "redis-master:6379", "The connection string to the Redis master as <hostname/ip>:<port>")
 	flag.StringVar(&slaveConnection, "slave", "redis-slave:6379", "The connection string to the Redis slave as <hostname/ip>:<port>")
@@ -20,11 +28,15 @@ func main() {
 	flag.StringVar(&slavePassword, "slave-password", "", "The password used to connect to the slave")
 	flag.Parse()
 
+	// Iniitialize metrics
+	getHealthStatus()
+
 	r := mux.NewRouter()
 	r.Path("/read/{key}").Methods("GET").HandlerFunc(readTodoHandler)
 	r.Path("/insert/{key}/{value}").Methods("GET").HandlerFunc(insertTodoHandler)
 	r.Path("/delete/{key}/{value}").Methods("GET").HandlerFunc(deleteTodoHandler)
 	r.Path("/health").Methods("GET").HandlerFunc(healthCheckHandler)
+	r.Path("/metrics").Methods("GET").Handler(prometheus.Handler())
 	r.Path("/whoami").Methods("GET").HandlerFunc(whoAmIHandler)
 
 	n := negroni.Classic()

--- a/util.go
+++ b/util.go
@@ -5,8 +5,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+
 
 	"gopkg.in/redis.v4"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func createRedisClient(addr, password string) *(redis.Client) {
@@ -17,11 +21,11 @@ func createRedisClient(addr, password string) *(redis.Client) {
 	})
 }
 
-func checkConnection(result map[string]string, key, connection, password, okString string) {
+func checkConnection(connection string, password string, okString string) (string) {
 	if _, err := createRedisClient(connection, password).Ping().Result(); err != nil {
-		result[key] = err.Error()
+		return err.Error()
 	} else {
-		result[key] = okString
+		return okString
 	}
 }
 
@@ -49,4 +53,74 @@ func generateJSONResponse(rw http.ResponseWriter, toMarshal interface{}) {
 		http.Error(rw, err.Error(), 500)
 	}
 	rw.Write(responseJSON)
+}
+
+var redisMastersTotal = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "todoapp_redis_masters_total",
+		Help: "Total count of available redis masters",
+	},
+	[]string{"instance", "version"},
+)
+
+var redisMastersHealthyTotal = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "todoapp_redis_masters_healthy_total",
+		Help: "Total count of healthy redis masters",
+	},
+	[]string{"instance", "version"},
+)
+
+var redisSlavesTotal = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "todoapp_redis_slaves_total",
+		Help: "Total count of available redis slaves",
+	},
+	[]string{"instance", "version"},
+)
+
+var redisSlavesHealthyTotal = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "todoapp_redis_slaves_healthy_total",
+		Help: "Total count of healthy redis slaves",
+	},
+	[]string{"instance", "version"},
+)
+
+func registerMetrics() {
+	prometheus.MustRegister(redisMastersTotal)
+	prometheus.MustRegister(redisMastersHealthyTotal)
+	prometheus.MustRegister(redisSlavesTotal)
+	prometheus.MustRegister(redisSlavesHealthyTotal)
+}
+
+func getHealthStatus() (map[string]string) {
+	okString := "ok"
+	result := map[string]string{"self": okString}
+	hostname, err := os.Hostname()
+
+	if err != nil { //TODO we'll just ignore any errors :)
+		hostname = "UNKNOWN"
+	}
+
+	result["redis-master"] = checkConnection(masterConnection, masterPassword, okString)
+	redisMastersTotal.WithLabelValues(hostname, APP_VERSION).Set(1.0)
+
+	if result["redis-master"] == okString {
+		redisMastersHealthyTotal.WithLabelValues(hostname, APP_VERSION).Set(1.0)
+	} else {
+		redisMastersHealthyTotal.WithLabelValues(hostname, APP_VERSION).Set(0.0)
+	}
+
+
+	result["redis-slave"] = checkConnection(slaveConnection, slavePassword, okString)
+	redisSlavesTotal.WithLabelValues(hostname, APP_VERSION).Set(1.0)
+
+	if result["redis-slave"] == okString {
+		redisSlavesHealthyTotal.WithLabelValues(hostname, APP_VERSION).Set(1.0)
+	} else {
+		redisSlavesHealthyTotal.WithLabelValues(hostname, APP_VERSION).Set(0.0)
+	}
+
+	return result
 }


### PR DESCRIPTION
This PR adds some rudimentary metric exports. Sorry for the bad code quality, that's my first _real_ contact with golang. :)

Feel free to comment.

```
$ http 192.168.99.100:3000/metrics
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 1494
Content-Type: text/plain; version=0.0.4
Date: Thu, 25 Aug 2016 22:49:35 GMT

# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0.0006728810000000001
go_gc_duration_seconds{quantile="0.25"} 0.0006728810000000001
go_gc_duration_seconds{quantile="0.5"} 0.0006728810000000001
go_gc_duration_seconds{quantile="0.75"} 0.0006728810000000001
go_gc_duration_seconds{quantile="1"} 0.0006728810000000001
go_gc_duration_seconds_sum 0.0006728810000000001
go_gc_duration_seconds_count 1
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 13
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.565608e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 4.348104e+06
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.443323e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 17878
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 425984
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.565608e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.357568e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 2.572288e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 6551
# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes_total counter
go_memstats_heap_released_bytes_total 0
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 7.929856e+06
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.4721653709963927e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 512
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 24429
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 4800
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 16384
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 39680
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 65536
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 4.194304e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.266429e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 458752
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 458752
# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 1.1606264e+07
# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
# TYPE http_request_duration_microseconds summary
http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 2809.849
http_request_duration_microseconds{handler="prometheus",quantile="0.9"} 3660.778
http_request_duration_microseconds{handler="prometheus",quantile="0.99"} 3660.778
http_request_duration_microseconds_sum{handler="prometheus"} 6470.627
http_request_duration_microseconds_count{handler="prometheus"} 2
# HELP http_request_size_bytes The HTTP request sizes in bytes.
# TYPE http_request_size_bytes summary
http_request_size_bytes{handler="prometheus",quantile="0.5"} 117
http_request_size_bytes{handler="prometheus",quantile="0.9"} 117
http_request_size_bytes{handler="prometheus",quantile="0.99"} 117
http_request_size_bytes_sum{handler="prometheus"} 234
http_request_size_bytes_count{handler="prometheus"} 2
# HELP http_requests_total Total number of HTTP requests made.
# TYPE http_requests_total counter
http_requests_total{code="200",handler="prometheus",method="get"} 2
# HELP http_response_size_bytes The HTTP response sizes in bytes.
# TYPE http_response_size_bytes summary
http_response_size_bytes{handler="prometheus",quantile="0.5"} 1385
http_response_size_bytes{handler="prometheus",quantile="0.9"} 1434
http_response_size_bytes{handler="prometheus",quantile="0.99"} 1434
http_response_size_bytes_sum{handler="prometheus"} 2819
http_response_size_bytes_count{handler="prometheus"} 2
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.18
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 8
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 9.445376e+06
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.47216482133e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.6695296e+07
# HELP todoapp_redis_masters_healthy_total Total count of healthy redis masters
# TYPE todoapp_redis_masters_healthy_total gauge
todoapp_redis_masters_healthy_total{instance="eb78784e9e6a",version="lates2t"} 1
# HELP todoapp_redis_masters_total Total count of available redis masters
# TYPE todoapp_redis_masters_total gauge
todoapp_redis_masters_total{instance="eb78784e9e6a",version="lates2t"} 1
# HELP todoapp_redis_slaves_healthy_total Total count of healthy redis slaves
# TYPE todoapp_redis_slaves_healthy_total gauge
todoapp_redis_slaves_healthy_total{instance="eb78784e9e6a",version="lates2t"} 1
# HELP todoapp_redis_slaves_total Total count of available redis slaves
# TYPE todoapp_redis_slaves_total gauge
todoapp_redis_slaves_total{instance="eb78784e9e6a",version="lates2t"} 1
```
