### PR TITLE
Added missing namespace

### DIFF
--- a/k8s-deployment/todo-app-config.yaml
+++ b/k8s-deployment/todo-app-config.yaml
@@ -14,3 +14,4 @@ data:
 kind: ConfigMap
 metadata:
   name: todo-app-config
+  namespace: todo-app


### PR DESCRIPTION
In my last MR I created a new configmap. Sadly I forgot to add a namespace. Thus a `kubectl apply -f k8s-deployment` will create the configmap in the default namespace. Thus the pods will not start. Not a major issue but inconvenient.